### PR TITLE
Add the meta keywords and description in the node layout

### DIFF
--- a/FrontBundle/Resources/views/Node/show.html.twig
+++ b/FrontBundle/Resources/views/Node/show.html.twig
@@ -7,10 +7,9 @@
         {% endblock %}
         <script src="{{ asset('/bundles/openorchestradisplay/libs/require.js') }}"></script>
         <script src="{{ asset('/bundles/openorchestradisplay/requireConf.js') }}"></script>
-        <meta name="ROBOTS" content="
-            {{- node.metaFollow ? 'FOLLOW': 'NOFOLLOW' -}},
-            {{- node.metaIndex ? 'INDEX': 'NOINDEX' -}}
-        ">
+        <meta name="robots" content="{{- node.metaFollow ? 'follow': 'nofollow' -}},{{- node.metaIndex ? 'index': 'noindex' -}}">
+        <meta name="description" content="{{ node.metaDescription }}">
+        <meta name="keywords" content="{{ node.metaKeywords }}">
     </head>
     <body>
         {% for area in node.areas %}


### PR DESCRIPTION
[OO-BUGFIX] Node meta description and meta keywords are now correctly inserted into the html dom
https://github.com/open-orchestra/open-orchestra-model-interface/pull/195
https://github.com/open-orchestra/open-orchestra-mongo-libs/pull/33
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/595
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1757
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/171
