### PR TITLE
add query parameter when block is private

### DIFF
--- a/FrontBundle/Resources/views/Node/area.html.twig
+++ b/FrontBundle/Resources/views/Node/area.html.twig
@@ -9,8 +9,7 @@
         {% else %}
             {% set nodeReference = blockReference.nodeId %}
         {% endif %}
-        {% set blockParameter = blockReference.blockParameter is defined ? blockReference.blockParameter : [] %}
-        {% set queryParams = generate_subquery(blockParameter, parameters|merge({'nodeId': nodeReference, 'blockId': blockReference.blockId})) %}
+        {% set queryParams = generate_subquery(blockReference, parameters|merge({'nodeId': nodeReference, 'blockId': blockReference.blockId})) %}
         {{ render_esi(url('open_orchestra_front_block', queryParams)) }}
     {% endfor %}
 </div>

--- a/FrontBundle/SubQuery/SubQueryGeneratorManager.php
+++ b/FrontBundle/SubQuery/SubQueryGeneratorManager.php
@@ -18,23 +18,40 @@ class SubQueryGeneratorManager
     }
 
     /**
-     * @param array $blockParameters
+     * @param array $block
      * @param array $baseSubQuery
      *
      * @return array
      */
-    public function generate(array $blockParameters, array $baseSubQuery)
+    public function generate(array $block, array $baseSubQuery)
     {
-        $subQuery = $baseSubQuery;
-        /** @var SubQueryGeneratorInterface $strategy */
-        foreach ($this->strategies as $strategy) {
-            foreach ($blockParameters as $blockParameter) {
-                if ($strategy->support($blockParameter)) {
-                    $subQuery = array_merge($subQuery, $strategy->generate($blockParameter));
+        $subQuery = array_merge($baseSubQuery, $this->generateSubQueryCache($block));
+        if(isset($block['blockParameter'])) {
+            /** @var SubQueryGeneratorInterface $strategy */
+            foreach ($this->strategies as $strategy) {
+                foreach ($block['blockParameter'] as $blockParameter) {
+                    if ($strategy->support($blockParameter)) {
+                        $subQuery = array_merge($subQuery, $strategy->generate($blockParameter));
+                    }
                 }
             }
         }
 
         return $subQuery;
+    }
+
+    /**
+     * @param $block
+     *
+     * @return array
+     */
+    public function generateSubQueryCache($block)
+    {
+        $cacheQuery = array();
+        if (isset($block['blockPrivate']) && true === $block['blockPrivate']) {
+            $cacheQuery = array('cache' => 'private');
+        }
+
+        return $cacheQuery;
     }
 }

--- a/FrontBundle/SubQuery/SubQueryGeneratorManager.php
+++ b/FrontBundle/SubQuery/SubQueryGeneratorManager.php
@@ -26,7 +26,7 @@ class SubQueryGeneratorManager
     public function generate(array $block, array $baseSubQuery)
     {
         $subQuery = array_merge($baseSubQuery, $this->generateSubQueryCache($block));
-        if(isset($block['blockParameter'])) {
+        if (isset($block['blockParameter'])) {
             /** @var SubQueryGeneratorInterface $strategy */
             foreach ($this->strategies as $strategy) {
                 foreach ($block['blockParameter'] as $blockParameter) {

--- a/FrontBundle/Tests/SubQuery/SubQueryGeneratorManagerTest.php
+++ b/FrontBundle/Tests/SubQuery/SubQueryGeneratorManagerTest.php
@@ -57,11 +57,11 @@ class SubQueryGeneratorManagerTest extends AbstractBaseTestCase
         return array(
             array(false, array(), array(), array(), array()),
             array(true, array(), array(), array(), array()),
-            array(true, array('foo'), $fooBarArray, array(), $fooBarArray),
-            array(true, array('foo'), array(), $fooBarArray, $fooBarArray),
-            array(false, array('foo'), $fooBarArray, array(), array()),
-            array(true, array('foo'), $fooBarArray, array('foo' => 'foo'), $fooBarArray),
-            array(true, array('foo', 'bar'), $fooBarArray, array('foo' => 'foo'), $fooBarArray),
+            array(true, array('blockParameter' => array('foo')), $fooBarArray, array(), $fooBarArray),
+            array(true, array('blockParameter' => array('foo')), array(), $fooBarArray, $fooBarArray),
+            array(false, array('blockParameter' => array('foo')), $fooBarArray, array(), array()),
+            array(true, array('blockParameter' => array('foo')), $fooBarArray, array('foo' => 'foo'), $fooBarArray),
+            array(true, array('blockParameter' => array('foo', 'bar')), $fooBarArray, array('foo' => 'foo'), $fooBarArray),
         );
     }
 }


### PR DESCRIPTION
[OO-FEATURE] Add a query parameter `cache=private` in the url when a private block is rendering

https://github.com/open-orchestra/open-orchestra-docs/pull/229
https://github.com/open-orchestra/open-orchestra-provision/pull/41
https://github.com/open-orchestra/open-orchestra-model-bundle/pull/636
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1853
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/191
