### PR TITLE
Remove nodeId as a parameter to route open_orchestra_base_node_preview

### DIFF
--- a/FrontBundle/Manager/ErrorPagesManager.php
+++ b/FrontBundle/Manager/ErrorPagesManager.php
@@ -83,7 +83,6 @@ class ErrorPagesManager
             'open_orchestra_base_node_preview',
             array(
                 'token' => $this->encrypter->encrypt($errorNode->getId()),
-                'nodeId' => $errorNode->getNodeId(),
                 'aliasId' => $aliasId
             )
         );


### PR DESCRIPTION
[OO-BCBREAK] Remove a useless parameter on open_orchestra_base_node_preview route
https://github.com/open-orchestra/open-orchestra-base-bundle/pull/117
https://github.com/open-orchestra/open-orchestra-front-bundle/pull/202
https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1971